### PR TITLE
Add issue pr template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+about: Create a report to help us improve
+
+title: "[Bug] "
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to Reproduce the Bug
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,28 @@
+name: Documentation Update
+about: Suggest an update to the documentation
+
+title: "[Documentation Update] "
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Documentation Update
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Location in Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_changes
+    attributes:
+      label: Suggested Changes
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/ISSUE_TEMPLATE/enhacement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhacement_proposal.yml
@@ -1,0 +1,28 @@
+name: Enhancement Proposal
+about: Propose an enhancement to this project
+
+title: "[Enhancement Proposal] "
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Enhancement Proposal
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+    validations:
+      required: true
+  - type: textarea
+    id: implementation_details
+    attributes:
+      label: Implementation Details
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature Request
+about: Suggest an idea for this project
+
+title: "[Feature Request] "
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Feature Request
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -1,0 +1,16 @@
+name: Other Issue
+about: Create an issue that doesn't fit into other categories
+
+title: ""
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Issue
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/ISSUE_TEMPLATE/question_help.yml
+++ b/.github/ISSUE_TEMPLATE/question_help.yml
@@ -1,0 +1,22 @@
+name: Question/Help Request
+about: Ask a question or request help
+
+title: "[Question/Help] "
+
+body:
+  - type: textarea
+    id: question_or_issue
+    attributes:
+      label: Question or Issue
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.yml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+title: ""
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: textarea
+    id: changes_made
+    attributes:
+      label: Changes Made
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information


### PR DESCRIPTION
Closes #42 

In this pull request, we are adding issue templates to streamline the process of creating new issues and raising a pull request. The templates include:

Bug Report Template
Feature Request Template
Enhancement Proposal Template
Documentation Update Template
Question/Help Template
Other Issue Template
PR Template

These templates will help standardize issue submissions and provide clear guidelines for contributors.

If any adjustments are needed, please feel free to suggest changes or let me know if there are specific preferences for the templates.